### PR TITLE
Bump to 0.2.0

### DIFF
--- a/lib/shared_mustache/version.rb
+++ b/lib/shared_mustache/version.rb
@@ -1,3 +1,3 @@
 module SharedMustache
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
shared_mustache no longer ships with a blank template.js file. Any apps using shared_mustache will now need to ensure they have their own template.js and that it is checked in to the source.