### PR TITLE
Add naive caching to partials

### DIFF
--- a/lib/shared_mustache/mustache_view.rb
+++ b/lib/shared_mustache/mustache_view.rb
@@ -1,7 +1,13 @@
 require 'mustache'
 
 class MustacheView < Mustache
+
+  def initialize
+    super
+    @partial_cache = {}
+  end
+
   def partial(name)
-    File.read("#{template_path}/#{name}.#{template_extension}")
+    @partial_cache[name] ||= File.read("#{template_path}/#{name}.#{template_extension}")
   end
 end


### PR DESCRIPTION
This commit adds caching to partials to reduce the number of disk reads
when the same partial is used more than once. The mustache gem still
does a lot of repeated CPU intensive work parsing the partial so I
would still advise against using partials inside loops until this
problem has been addressed in the mustache gem.