### PR TITLE
Update references to Hogan file

### DIFF
--- a/lib/shared_mustache/hogan.rb
+++ b/lib/shared_mustache/hogan.rb
@@ -13,10 +13,8 @@ module SharedMustache
     end
 
     def self.hogan_source
-      hogan_path = File.expand_path('../../vendor/assets/javascripts/hogan-2.0.0.js', File.dirname(__FILE__))
+      hogan_path = File.expand_path('../../vendor/assets/javascripts/hogan-2.0.0-hotfix.js', File.dirname(__FILE__))
       File.read(hogan_path)
     end
   end
 end
-
-

--- a/lib/shared_mustache/view_helpers.rb
+++ b/lib/shared_mustache/view_helpers.rb
@@ -8,7 +8,7 @@ module SharedMustache
       script_tags = file_list.map do |file|
         content_tag(:script, File.read(file), id: SharedMustache.file_name_to_id(file), type: 'text/mustache')
       end
-      script_tags << javascript_include_tag("hogan-2.0.0.js")
+      script_tags << javascript_include_tag("hogan-2.0.0-hotfix.js")
       script_tags.join('').html_safe
     end
 


### PR DESCRIPTION
A follow up to #8:

The hogan library file was renamed, but the compile Rake task and development view helpers weren't updated.

cc @edds 