### PR TITLE
Version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.2.1
+
+* Remove `typeof exports` check in Hogan libraries: https://github.com/alphagov/shared_mustache/pull/8.
+
+# 0.2.0
+
+* shared_mustache no longer ships with a blank template.js file. Any apps using shared_mustache will now need to ensure they have their own template.js and that it is checked in to the source.

--- a/lib/shared_mustache/version.rb
+++ b/lib/shared_mustache/version.rb
@@ -1,3 +1,3 @@
 module SharedMustache
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
* Removes `typeof exports` check in Hogan libraries (https://github.com/alphagov/shared_mustache/pull/8, https://github.com/alphagov/shared_mustache/pull/9).

Also adds a changelog file.