### PR TITLE
Update mustache dependency to 1.0.2

### DIFF
--- a/shared_mustache.gemspec
+++ b/shared_mustache.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Share mustache between Rails templates and the browser (using compiled hogan.js templates).}
   gem.homepage      = ""
 
-  gem.add_dependency 'mustache', '~> 0.99.4'
+  gem.add_dependency 'mustache', '~> 1.0.2'
   gem.add_dependency 'execjs', '>= 1.2.4'
 
   gem.add_development_dependency "gem_publisher", "~> 1.1.1"


### PR DESCRIPTION
The change we want to include is the performance improvement when using partials in loops: https://github.com/mustache/mustache/pull/205

The breaking change from 0.99 to 1.0 is that mustache now requires Ruby >= 2.0.