### PR TITLE
Bump version to 1.0.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+* Add hogan.js to assets.precompile for compatibility with sprockets-rails 3.x
+
 # 1.0.0
 
 * Bump mustache to 1.0.2. This requires Ruby 2.0 or higher.

--- a/lib/shared_mustache/version.rb
+++ b/lib/shared_mustache/version.rb
@@ -1,3 +1,3 @@
 module SharedMustache
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Release v 1.0.1 with latest infrastrucuture changes and sprockets 3 compatibility.